### PR TITLE
feat: add alt text to img and adjust Image component size

### DIFF
--- a/src/components/sticky-scroll-reveal.tsx
+++ b/src/components/sticky-scroll-reveal.tsx
@@ -52,6 +52,7 @@ const content: {
       <img
         className={"w-full md:h-[320px] h-[200px] lg:h-full object-cover"}
         loading={"lazy"}
+        alt={"Illustration de layout"}
         src={"/images/material-theme.webp"}
       />
     ),

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -67,7 +67,7 @@ import {LinearGradient} from "@components/LinearGradient";
                     <Line client:idle visible isFirst icon={faCircle}/>
                 </div>
                 <div class="padding !pb-16">
-                    <Image class="rounded-xl" src={portrait} height={64} width={64} alt="Joël"></Image>
+                    <Image class="rounded-xl h-16 w-16" src={portrait} height={96} width={96} alt="Joël"></Image>
                     <h1 class="text-headline-large my-6">
                         Joël VIGREUX
                     </h1>


### PR DESCRIPTION
Added an alt attribute to the image in sticky-scroll-reveal.tsx for better accessibility. Adjusted the height and width of the Image component in index.astro to maintain consistent display sizes.